### PR TITLE
Fix: Free Badge Controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,7 +2041,7 @@ version = "0.1.0"
 
 [[package]]
 name = "hubbitos_backend"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "actix-web",
  "actix-web-lab",
@@ -4358,7 +4358,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "actix-web",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [workspace]

--- a/src/infra/http/controllers/free_badges_controller.rs
+++ b/src/infra/http/controllers/free_badges_controller.rs
@@ -116,8 +116,8 @@ impl FreeBadgesController {
         let body = body.into_inner();
 
         let service = match update_free_badge_service_factory::exec().await {
-            Ok(service) => service,
-            Err(error) => return error,
+            Left(service) => service,
+            Right(error) => return error,
         };
 
         let result = service.exec(UpdateFreeBadgeParams {


### PR DESCRIPTION
Fixed the service factory result pattern match. It was being treated as a result, but it is actually a Either result.